### PR TITLE
Add New Game Button

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -17,6 +17,27 @@ fn conf() -> Conf {
 
 #[macroquad::main(conf)]
 async fn main() {
+    loop {
+        let (answers, questions) = generate_new_puzzle().await;
+        let mut state = game::State::new();
+
+        loop {
+            clear_background(DARKGRAY);
+            render::letter_square(&state);
+            render::hints(&questions);
+            render::finished_state(&state);
+            
+            if render::new_game_button() {
+                break;
+            }
+            
+            game::update(&mut state, &answers);
+            next_frame().await
+        }
+    }
+}
+
+async fn generate_new_puzzle() -> (crate::puzzle::Square, crate::puzzle::Square) {
     let result = Arc::new(Mutex::new(generate::Result::default()));
 
     let result_for_generation = Arc::clone(&result);
@@ -36,15 +57,6 @@ async fn main() {
 
     let answers = result.lock().unwrap().clone().answers.unwrap();
     let questions = result.lock().unwrap().clone().questions.unwrap();
-
-    let mut state = game::State::new();
-
-    loop {
-        clear_background(DARKGRAY);
-        render::letter_square(&state);
-        render::hints(&questions);
-        render::finished_state(&state);
-        game::update(&mut state, &answers);
-        next_frame().await
-    }
+    
+    (answers, questions)
 }

--- a/src/render.rs
+++ b/src/render.rs
@@ -124,3 +124,30 @@ pub fn finished_state(state: &crate::game::State) {
         color,
     );
 }
+
+pub fn new_game_button() -> bool {
+    let button_x = screen_width() * 0.8;
+    let button_y = screen_height() * 0.85;
+    let button_width = screen_width() * 0.15;
+    let button_height = screen_height() * 0.08;
+    
+    let mouse_pos = mouse_position();
+    let mouse_over = mouse_pos.0 >= button_x && mouse_pos.0 <= button_x + button_width 
+                    && mouse_pos.1 >= button_y && mouse_pos.1 <= button_y + button_height;
+    
+    let button_color = if mouse_over { LIGHTGRAY } else { GRAY };
+    let text_color = if mouse_over { BLACK } else { WHITE };
+    
+    draw_rectangle(button_x, button_y, button_width, button_height, button_color);
+    draw_rectangle_lines(button_x, button_y, button_width, button_height, 2.0, WHITE);
+    
+    draw_text(
+        "New Game",
+        button_x + button_width * 0.15,
+        button_y + button_height * 0.65,
+        screen_width() * 0.02,
+        text_color,
+    );
+    
+    mouse_over && is_mouse_button_pressed(MouseButton::Left)
+}


### PR DESCRIPTION
## Summary
- Added clickable "New Game" button in bottom-right corner with hover effects
- Refactored main game loop to support puzzle regeneration when button is clicked
- Extracted puzzle generation logic into separate async function for reusability

## Test plan
- [ ] Verify button appears in bottom-right corner of game window
- [ ] Test button hover effects (color changes on mouse over)
- [ ] Click button to ensure new puzzle generates with fresh board state
- [ ] Confirm loading screen appears during new puzzle generation

🤖 Generated with [Claude Code](https://claude.ai/code)